### PR TITLE
SNI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,6 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python33-x64"
-      DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,9 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
-      DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36-x64"
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
 
 install:        

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,8 @@ setup(
         ],
     install_requires=[
         'six',
-        'certauth',
+        'certauth>=1.1.5',
         ],
-    dependency_links=[
-        'git+https://github.com/ikreymer/certauth.git@customize-duration#egg=certauth-1.1.5',
-    ],
     zip_safe=True,
     data_files=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PyTest(TestCommand):
 
 setup(
     name='wsgiprox',
-    version='1.2.2',
+    version='1.3',
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
         'six',
         'certauth',
         ],
+    dependency_links=[
+        'git+https://github.com/ikreymer/certauth.git@customize-duration#egg=certauth-1.1.5',
+    ],
     zip_safe=True,
     data_files=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/wsgiprox/wsgiprox.py
+++ b/wsgiprox/wsgiprox.py
@@ -308,7 +308,7 @@ class WSGIProxMiddleware(object):
         self.ca = CertificateAuthority(ca_file=ca_file,
                                        certs_dir=certs_dir,
                                        ca_name=ca_name,
-                                       cert_start=-3600)
+                                       cert_not_before=-3600)
 
         self.use_wildcard = proxy_options.get('use_wildcard_certs', True)
 


### PR DESCRIPTION
- Add SNI support
- Ensure HTTP Proxy has `Proxy-Connection` header
- Use latest certauth, set cert not-before to be an hour before now to account for time differences.
- v1.3