### PR TITLE
windows: fix appveyor tests with py3.6.4

### DIFF
--- a/test/test_wsgiprox.py
+++ b/test/test_wsgiprox.py
@@ -5,6 +5,16 @@ import gevent
 
 import sys
 
+
+# Fix for KEEP_CNT in Windows, per (https://bugs.python.org/issue32394#msg308943)
+if sys.version_info >= (3,6,4) and hasattr(sys, 'getwindowsversion') and sys.getwindowsversion()[0] < 10:
+    if hasattr(socket, 'TCP_KEEPCNT'):
+        del socket.TCP_KEEPCNT
+
+    if hasattr(socket, 'TCP_FASTOPEN'):
+        del socket.TCP_FASTOPEN
+
+
 import requests
 import websocket
 import pytest

--- a/test/test_wsgiprox.py
+++ b/test/test_wsgiprox.py
@@ -8,6 +8,8 @@ import sys
 
 # Fix for KEEP_CNT in Windows, per (https://bugs.python.org/issue32394#msg308943)
 if sys.version_info >= (3,6,4) and hasattr(sys, 'getwindowsversion') and sys.getwindowsversion()[0] < 10:
+    import socket
+
     if hasattr(socket, 'TCP_KEEPCNT'):
         del socket.TCP_KEEPCNT
 


### PR DESCRIPTION
Remove TCP_KEEPCNT if python 3.6.4, windows < 10, see websocket-client/websocket-client#404